### PR TITLE
Fix Fahrstuhl, Heizungsrohre und Kochmöglichkeit Merkmale

### DIFF
--- a/src/details/result/AuswertungModal/MerkmaleTable.tsx
+++ b/src/details/result/AuswertungModal/MerkmaleTable.tsx
@@ -208,10 +208,7 @@ export function MerkmaleTable() {
         "[Gebäude-] EVK>235":
           "Energieverbrauchskennwert größer als 235 kWh/(m²a)",
         "[Gebäude-] kein Aufzug":
-          jahr == "2015"
-            ? "Nur wenn Sondermerkmal „Aufzug im Haus“ nicht zutrifft Personenaufzug bei weniger als fünf Obergeschossen"
-            : "Personenaufzug bei weniger als fünf Obergeschossen",
-
+          "Wohnung ab fünftem Obergeschoss ohne Personenaufzug",
         "[Gebäude+] geschlossener Fahrradraum":
           jahr == "2015"
             ? "Abschließbarer Fahrradabstellraum innerhalb oder außerhalb des Gebäudes"
@@ -229,7 +226,9 @@ export function MerkmaleTable() {
         "[Gebäude+] Gegensprechanlage":
           "Gegen-/Wechselsprechanlage mit Videokontakt und elektrischem Türöffner",
         "[Gebäude+] Aufzug":
-          "Wohnung ab fünftem Obergeschoss ohne Personenaufzug",
+          jahr == "2015"
+            ? "Nur wenn Sondermerkmal „Aufzug im Haus“ nicht zutrifft Personenaufzug bei weniger als fünf Obergeschossen"
+            : "Personenaufzug bei weniger als fünf Obergeschossen",
         "[Gebäude+] Wärmedämmung":
           jahr == "2015"
             ? "Wärmedämmung zusätzlich zur vorhandenen Bausubstanz oder Einbau/Installation einer modernen Heizanlage nach dem 1.7.1994 (wenn Baujahr vor diesem Zeitpunkt)"

--- a/src/form/flow.fm.json
+++ b/src/form/flow.fm.json
@@ -7688,7 +7688,7 @@
                                       }
                                     ]
                                   },
-                                  "note": "Merkmal >=2017:\nWohnung ab fünftem Obergeschoss  ohne Personenaufzug [--]\n\nNein -> Check\nNicht sicher -> Nicht sicher"
+                                  "note": "Merkmal >=2017:\nWohnung ab fünftem Obergeschoss  ohne Personenaufzug [--]\n\nJa -> Check\nNicht sicher -> Nicht sicher"
                                 }
                               ]
                             }

--- a/src/form/rechner/MerkmalsGruppen.ts
+++ b/src/form/rechner/MerkmalsGruppen.ts
@@ -77,7 +77,7 @@ export const merkmaleByGruppe = {
     con: {
       kochlos: [
         { "Küche hat Kochmöglichkeit": "Nein" },
-        { "Küche hat Gas/Elektroherd ohne Backofen": "Ja" },
+        { "Küche hat Gas/Elektroherd ohne Backofen": "Nein" },
       ],
       "keine Spüle": { "Küche hat Spüle": "Nein" },
       kaumwarm: { "Küche hat Warmwasser": "Nein" },
@@ -103,7 +103,7 @@ export const merkmaleByGruppe = {
       },
       Fußbodenheizung: { "Wohnung hat Fußbodenheizung": "Ja" },
       "Heizungsrohre nicht sichtbar": {
-        "Wohnung hat sichtbare Heizungsrohe": "Ja",
+        "Wohnung hat sichtbare Heizungsrohe": "Nein",
       },
       "hochwertiger Boden": {
         "Wohnung hat hochwertigen Bodenbelag": "Ja",
@@ -151,7 +151,9 @@ export const merkmaleByGruppe = {
         "Gebäude hat Treppenhaus in gutem Zustand": "Ja",
       },
       "gut Instand": { "Gebäude ist in gutem Zustand": "Ja" },
-      Aufzug: { "Gebäude hat <5 Stockwerke und Fahrstuhl": "Ja" },
+      Aufzug: {
+        "Gebäude hat <5 Stockwerke und Fahrstuhl": "Ja",
+      },
       "geschlossener Fahrradraum": [
         { "Gebäude hat Fahrradstellplätze mit Anschließmöglichkeit": "Ja" },
         { "Gebäude hat Fahrradabstellraum": "Ja" },
@@ -193,7 +195,7 @@ export const merkmaleByGruppe = {
         "Gebäude ist in schlechtem Zustand": "Ja",
       },
       "kein Aufzug": {
-        "Gebäude hat >=5 Stockwerke und kein Fahrstuhl": "Nein",
+        "Gebäude hat >=5 Stockwerke und kein Fahrstuhl": "Ja",
       },
       "keine Fahrradabstellmöglichkeit": {
         "Gebäude hat Fahrradabstellmöglichkeit": "Nein",

--- a/src/form/rechner/answer-test-reset.ts
+++ b/src/form/rechner/answer-test-reset.ts
@@ -40,7 +40,8 @@ export const MERKMAL_RESET_ANSWERS = {
 
   // Küche-
   "Küche hat Kochmöglichkeit": "Ja",
-  "Küche hat Gas/Elektroherd ohne Backofen": "Nein",
+  "Küche hat Gas/Elektroherd": "Ja",
+  "Küche hat Gas/Elektroherd ohne Backofen": "Ja",
   "Küche hat Spüle": "Ja",
   "Küche hat Warmwasser": "Ja",
   "Küche hat Heizung": "Ja",
@@ -57,7 +58,7 @@ export const MERKMAL_RESET_ANSWERS = {
   "Wohnung hat verstärkte Tür": "Nein",
   "Wohnung hat Kaltwasserzähler": "Nein",
   "Wohnung hat Fußbodenheizung": "Nein",
-  "Wohnung hat sichtbare Heizungsrohe": "Nein",
+  "Wohnung hat sichtbare Heizungsrohe": "Ja",
   "Wohnung hat hochwertigen Bodenbelag": "Nein",
   "Wohnung hat Internetanschluss": "Nein",
   "Wohnung hat aufwendige Wand- und Deckenverkleidung": "Nein",
@@ -93,7 +94,7 @@ export const MERKMAL_RESET_ANSWERS = {
   "Gebäude hat Gegensprechanlage": "Ja",
   "Gebäude hat Treppenhaus in schlechtem Zustand": "Nein",
   "Gebäude ist in schlechtem Zustand": "Nein",
-  "Gebäude hat >=5 Stockwerke und kein Fahrstuhl": "Ja",
+  "Gebäude hat >=5 Stockwerke und kein Fahrstuhl": "Nein",
   "Gebäude hat Fahrradabstellmöglichkeit": "Ja",
   "Gebäude hat privaten Abstellraum": "Ja",
   "Gebäude hat privaten Keller": "Ja",


### PR DESCRIPTION
- Fixes: Ab 5. Stockwerk ohne Fahrstuhl: Merkmal Auswertung war falsch herum
- Fixes (nicht) sichtbare Heizungsrohre: Merkmal Auswertung war falsch herum
- Fixes "Keine Kochmöglichkeit oder Gas-/ Elektroherd ohne Backofen": Merkmal Auswertung war falsch herum)