### PR TITLE
Fix typos in FAQ

### DIFF
--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -60,7 +60,7 @@
   "FAQ 11 Frage": "Warum macht ihr das?",
   "FAQ 11 Antwort": "Wir wollen, dass möglichst viele Mieter*innen die Mietpreisbremse ziehen. Denn wir wollen bezahlbaren Wohnraum für alle Berliner*innen.",
   "FAQ 12 Frage": "Was passiert mit meinen Daten?",
-  "FAQ 12 Antwort": "Die Antworten zu den einzelnen Merkmalen des Mietenchecks bzw. Mietspiegels auf unseren Servern gespeichert. Dabei werden allerdings keine personenbezogenen Daten gespeichert, insbesondere erfolgt die Speicherung also ohne die angegebenen Adressdaten der Nutzer*innen. Adressdaten der Nutzer*innen werden ausschließlich dann auf unseren Servern gespeichert, wenn die Nutzer*innen sich einen Link zur späteren Weiterbeantwortung des Mietenchecks - gegebenenfalls auf einem anderen Gerät - zuschicken lassen und dabei explizit in die Speicherung ihrer Adressdaten zu diesem Zwecke eingewilligt haben.",
+  "FAQ 12 Antwort": "Die Antworten zu den einzelnen Merkmalen des Mietenchecks bzw. Mietspiegels werden auf unseren Servern gespeichert. Dabei werden allerdings keine personenbezogenen Daten gespeichert, insbesondere erfolgt die Speicherung also ohne die angegebenen Adressdaten der Nutzer*innen. Adressdaten der Nutzer*innen werden ausschließlich dann auf unseren Servern gespeichert, wenn die Nutzer*innen sich einen Link zur späteren Weiterbeantwortung des Mietenchecks - gegebenenfalls auf einem anderen Gerät - zuschicken lassen und dabei explizit in die Speicherung ihrer Adressdaten zu diesem Zwecke eingewilligt haben.",
   "FAQ 13 Frage": "Kann ich euch unterstützen?",
   "FAQ 13 Antwort": "Ja! Hier findest du alle Möglichkeiten zum Mitmachen: https://dwenteignen.de/mitmachen",
   "next_question": "Nächste Frage",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -61,7 +61,7 @@
     "FAQ 11 Frage": "Why are you doing this?",
     "FAQ 11 Antwort": "We want as many tenants as possible to use the rent cap. Because we want affordable housing for all Berliners.",
     "FAQ 12 Frage": "What happens to my data?",
-    "FAQ 12 Antwort": "The answers to the individual features of the rent check or rent index are stored on our servers. However, no personal data is stored in this process. stored, in particular the storage takes place without the specified address data of the users. Users' address data is only stored on our servers if the users have a link sent to them for later answering the rent check - possibly on another device - and have explicitly consented to the storage of their address data for this purpose.",
+    "FAQ 12 Antwort": "The answers to the individual features of the rent check or rent index are stored on our servers. However, no personal data is stored in this process; in particular the storage takes place without the specified address data of the users. Users' address data is only stored on our servers if the users have a link sent to them for later answering the rent check - possibly on another device - and have explicitly consented to the storage of their address data for this purpose.",
     "FAQ 13 Frage": "Can I support you?",
     "FAQ 13 Antwort": "Yes! Here you can find all the options for getting involved: https://dwenteignen.de/mitmachen",
     "next_question": "Next",


### PR DESCRIPTION
I found a typo in the English translation of an FAQ. While double checking it against the German version, I think I found a verb missing? Do let me know if the extra 'werden' is incorrect.