### PR TITLE
Refactors type to use enums instead of string literals

### DIFF
--- a/src/2024/form/api.ts
+++ b/src/2024/form/api.ts
@@ -6,7 +6,7 @@ import { parseAdresse } from "~/utils";
 
 import { baujahrSpannenByMietspiegeljahr } from "../mietspiegel/baujahrSpannen";
 import { preisspannenByMietspiegeljahr } from "../mietspiegel/preisspannen";
-import { Mietspiegeljahr } from "../mietspiegel/types";
+import { o_Mietspiegeljahr as Mietspiegeljahr } from "../mietspiegel/types";
 import { answersToMerkmalStateMapping } from "./mappings/merkmale";
 import { answersToSondermerkmalStateMapping } from "./mappings/sondermerkmale";
 import { vertragsdatumToMietspiegelJahrMapping } from "./mappings/vertragsdatum";

--- a/src/2024/form/mappings/vertragsdatum.ts
+++ b/src/2024/form/mappings/vertragsdatum.ts
@@ -1,5 +1,5 @@
 import { FinalAnswers } from "~/2024/form/flow-machine";
-import { Mietspiegeljahr } from "~/2024/mietspiegel/types";
+import { o_Mietspiegeljahr as Mietspiegeljahr } from "~/2024/mietspiegel/types";
 
 export const vertragsdatumToMietspiegelJahrMapping = {
   "<2015": undefined,

--- a/src/2024/mietspiegel/ausstattungsAbzuege.ts
+++ b/src/2024/mietspiegel/ausstattungsAbzuege.ts
@@ -1,95 +1,100 @@
-import { BaujahrSpanneInMietspiegeljahr, Mietspiegeljahr } from "./types";
+import { Mietspiegeljahr, Baujahr, AusstattungsAbzuege } from "./types";
 
-export const ausstattungsAbzuegeByYear = {
-  "2015": {
-    "-1918": {
-      "!SH && !Bad": 2.65,
-      "!SH || !Bad": 1.94,
-    },
-    "1919-1949": {
-      "!SH && !Bad": 2.65,
-      "!SH || !Bad": 1.67,
-    },
-    "1950-1964": {
-      "!SH && !Bad": 1.03,
-      "!SH || !Bad": 1.03,
-    },
+const AusstattungsAbzuege2015: AusstattungsAbzuege = {
+  [Baujahr.Pre_1918]: {
+    "!SH && !Bad": 2.65,
+    "!SH || !Bad": 1.94,
   },
-  "2017": {
-    "-1918": {
-      "!SH && !Bad": 1.34,
-      "!SH || !Bad": 0.87,
-    },
-    "1919-1949": {
-      "!SH && !Bad": 0.87,
-      "!SH || !Bad": 0.35,
-    },
-    "1950-1964": {
-      "!SH && !Bad": 0.81,
-      "!SH || !Bad": 0.81,
-    },
+  [Baujahr.Range_1919_1949]: {
+    "!SH && !Bad": 2.65,
+    "!SH || !Bad": 1.67,
   },
-  "2019": {
-    "-1918": {
-      "!SH && !Bad": 2.2,
-      "!SH || !Bad": 1.41,
-    },
-    "1919-1949": {
-      "!SH && !Bad": 2.2,
-      "!SH || !Bad": 0.43,
-    },
-    "1950-1964": {
-      "!SH && !Bad": 1.45,
-      "!SH || !Bad": 1.45,
-    },
+  [Baujahr.Range_1950_1964]: {
+    "!SH && !Bad": 1.03,
+    "!SH || !Bad": 1.03,
   },
-  "2021": {
-    "-1918": {
-      "!SH && !Bad": 2.22,
-      "!SH || !Bad": 1.43,
-    },
-    "1919-1949": {
-      "!SH && !Bad": 2.22,
-      "!SH || !Bad": 0.43,
-    },
-    "1950-1964": {
-      "!SH && !Bad": 1.47,
-      "!SH || !Bad": 1.47,
-    },
+};
+
+const AusstattungsAbzuege2017: AusstattungsAbzuege = {
+  [Baujahr.Pre_1918]: {
+    "!SH && !Bad": 1.34,
+    "!SH || !Bad": 0.87,
   },
-  "2023": {
-    "-1918": {
-      "!SH && !Bad": 2.34,
-      "!SH || !Bad": 1.51,
-    },
-    "1919-1949": {
-      "!SH && !Bad": 2.34,
-      "!SH || !Bad": 0.45,
-    },
-    "1950-1964": {
-      "!SH && !Bad": 1.55,
-      "!SH || !Bad": 1.55,
-    },
+  [Baujahr.Range_1919_1949]: {
+    "!SH && !Bad": 0.87,
+    "!SH || !Bad": 0.35,
   },
-  "2024": {
-    "-1918": {
-      "!SH && !Bad": 0.45,
-      "!SH || !Bad": 0.45,
-    },
-    "1919-1949": {
-      "!SH && !Bad": 0.45,
-      "!SH || !Bad": 0.45,
-    },
-    "1950-1964": {
-      "!SH && !Bad": 0.45,
-      "!SH || !Bad": 0.45,
-    },
+  [Baujahr.Range_1950_1964]: {
+    "!SH && !Bad": 0.81,
+    "!SH || !Bad": 0.81,
   },
-} satisfies {
-  [Jahr in Mietspiegeljahr]: Partial<{
-    [Baujahr in BaujahrSpanneInMietspiegeljahr[Jahr]]: {
-      "!SH || !Bad": number;
-      "!SH && !Bad": number;
-    };
-  }>;
+};
+
+const AusstattungsAbzuege2019: AusstattungsAbzuege = {
+  [Baujahr.Pre_1918]: {
+    "!SH && !Bad": 2.2,
+    "!SH || !Bad": 1.41,
+  },
+  [Baujahr.Range_1919_1949]: {
+    "!SH && !Bad": 2.2,
+    "!SH || !Bad": 0.43,
+  },
+  [Baujahr.Range_1950_1964]: {
+    "!SH && !Bad": 1.45,
+    "!SH || !Bad": 1.45,
+  },
+};
+
+const AusstattungsAbzuege2021: AusstattungsAbzuege = {
+  [Baujahr.Pre_1918]: {
+    "!SH && !Bad": 2.22,
+    "!SH || !Bad": 1.43,
+  },
+  [Baujahr.Range_1919_1949]: {
+    "!SH && !Bad": 2.22,
+    "!SH || !Bad": 0.43,
+  },
+  [Baujahr.Range_1950_1964]: {
+    "!SH && !Bad": 1.47,
+    "!SH || !Bad": 1.47,
+  },
+};
+
+const AusstattungsAbzuege2023: AusstattungsAbzuege = {
+  [Baujahr.Pre_1918]: {
+    "!SH && !Bad": 2.34,
+    "!SH || !Bad": 1.51,
+  },
+  [Baujahr.Range_1919_1949]: {
+    "!SH && !Bad": 2.34,
+    "!SH || !Bad": 0.45,
+  },
+  [Baujahr.Range_1950_1964]: {
+    "!SH && !Bad": 1.55,
+    "!SH || !Bad": 1.55,
+  },
+};
+
+const AusstattungsAbzuege2024: AusstattungsAbzuege = {
+  [Baujahr.Pre_1918]: {
+    "!SH && !Bad": 0.45,
+    "!SH || !Bad": 0.45,
+  },
+  [Baujahr.Range_1919_1949]: {
+    "!SH && !Bad": 0.45,
+    "!SH || !Bad": 0.45,
+  },
+  [Baujahr.Range_1950_1964]: {
+    "!SH && !Bad": 0.45,
+    "!SH || !Bad": 0.45,
+  },
+};
+
+export const ausstattungsAbzuegeByYear : Record<Mietspiegeljahr, AusstattungsAbzuege> = {
+  [Mietspiegeljahr._2015]: AusstattungsAbzuege2015,
+  [Mietspiegeljahr._2017]: AusstattungsAbzuege2017,
+  [Mietspiegeljahr._2019]: AusstattungsAbzuege2019,
+  [Mietspiegeljahr._2021]: AusstattungsAbzuege2021,
+  [Mietspiegeljahr._2023]: AusstattungsAbzuege2023,
+  [Mietspiegeljahr._2024]: AusstattungsAbzuege2024,
 };

--- a/src/2024/mietspiegel/baujahrSpannen.ts
+++ b/src/2024/mietspiegel/baujahrSpannen.ts
@@ -1,4 +1,4 @@
-import { Baujahr, Mietspiegeljahr } from "./types";
+import { o_Baujahr, o_Mietspiegeljahr as Mietspiegeljahr } from "./types";
 
 export const baujahrSpannenByMietspiegeljahr = {
   "2015": [
@@ -64,4 +64,4 @@ export const baujahrSpannenByMietspiegeljahr = {
     "2010-2015",
     "2016-2022",
   ],
-} satisfies { [key in Mietspiegeljahr]: Baujahr[] };
+} satisfies { [key in Mietspiegeljahr]: o_Baujahr[] };

--- a/src/2024/mietspiegel/preisspannen.ts
+++ b/src/2024/mietspiegel/preisspannen.ts
@@ -1,6 +1,6 @@
 import {
   BaujahrSpanneInMietspiegeljahr,
-  Mietspiegeljahr,
+  o_Mietspiegeljahr as Mietspiegeljahr,
   Preisspanne,
   Wohnflaeche,
   Wohnlage,

--- a/src/2024/mietspiegel/sondermerkmale.ts
+++ b/src/2024/mietspiegel/sondermerkmale.ts
@@ -1,6 +1,6 @@
 import {
   BaujahrSpanneInMietspiegeljahr,
-  Mietspiegeljahr,
+  o_Mietspiegeljahr as Mietspiegeljahr,
   Sondermerkmal,
 } from "./types";
 

--- a/src/2024/mietspiegel/types.ts
+++ b/src/2024/mietspiegel/types.ts
@@ -12,7 +12,7 @@ type Unterwert = number;
 type Oberwert = number;
 export type Preisspanne = [Mittelwert, Unterwert, Oberwert];
 
-export type Mietspiegeljahr =
+export type o_Mietspiegeljahr =
   | "2015"
   | "2017"
   | "2019"
@@ -20,9 +20,42 @@ export type Mietspiegeljahr =
   | "2023"
   | "2024";
 
+export const enum Mietspiegeljahr {
+  _2015 = "2015",
+  _2017 = "2017",
+  _2019 = "2019",
+  _2021 = "2021",
+  _2023 = "2023",
+  _2024 = "2024",
+}
+
+export type AusstattungsAbzuege = Partial<Record<Baujahr, {
+  "!SH || !Bad": number;
+  "!SH && !Bad": number;
+}>>
+
 export type Wohnlage = "einfach" | "mittel" | "gut";
 
-export type Baujahr =
+export const enum Baujahr {
+  Pre_1918 = "-1918",
+  Range_1919_1949 = "1919-1949",
+  Range_1950_1964 = "1950-1964",
+  Range_1965_1972 = "1965-1972",
+  Range_1973_1985 = "W:1973-1985",
+  Range_West_1973_1990 = "W:1973-1990",
+  Range_West_1986_1990 = "W:1986-1990",
+  Range_Ost_1973_1990 = "O:1973-1990",
+  Range_1991_2001 = "1991-2001",
+  Range_1991_2002 = "1991-2002",
+  Range_2002_2009 = "2002-2009",
+  Range_2003_2013 = "2003-2013",
+  Range_2003_2015 = "2003-2015",
+  Range_2003_2017 = "2003-2017",
+  Range_2010_2015 = "2010-2015",
+  Range_2016_2022 = "2016-2022",
+}
+
+export type o_Baujahr =
   | "-1918"
   | "1919-1949"
   | "1950-1964"
@@ -44,7 +77,7 @@ export type BaujahrSpanne =
   (typeof baujahrSpannenByMietspiegeljahr)[keyof typeof baujahrSpannenByMietspiegeljahr][number];
 
 export type BaujahrSpanneInMietspiegeljahr = {
-  [Jahr in Mietspiegeljahr]: (typeof baujahrSpannenByMietspiegeljahr)[Jahr][number];
+  [Jahr in o_Mietspiegeljahr]: (typeof baujahrSpannenByMietspiegeljahr)[Jahr][number];
 };
 
 export type Wohnflaeche =


### PR DESCRIPTION
Example of how we could use enums instead of string literals to add more clarity to what the strings mean and how they're 'grouped'. 

Ex. `"2015"` could theoretically be a `Baujahr` or a `Mietspiegeljahr`, but when you use the enum, it's clear which one you mean.

This PR is intended more as a proof of concept and a way to comment and point to code. If we like it, we could go ahead and merge, but the goal is more to start a conversation on how we could make the code clearer. 

Just to be extra clear, I'm no Typescript pro, so it's possible there are yet better ways, but I feel like this is an improvement.